### PR TITLE
Fix wrong signature of BootServices::allocate_pages

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -520,7 +520,7 @@ pub struct BootServices {
         AllocateType,
         MemoryType,
         usize,
-        crate::base::PhysicalAddress,
+        *mut crate::base::PhysicalAddress,
     ) -> crate::base::Status},
     pub free_pages: eficall!{fn(
         crate::base::PhysicalAddress,


### PR DESCRIPTION
Argument 4 of that function should have the type
`*mut PhysicalAddress` instead of just `PhysicalAddress`.