### PR TITLE
protocols/loaded_image: Expose reserved field

### DIFF
--- a/src/protocols/loaded_image.rs
+++ b/src/protocols/loaded_image.rs
@@ -17,7 +17,7 @@ pub struct Protocol {
 
     pub device_handle: crate::base::Handle,
     pub file_path: *mut crate::protocols::device_path::Protocol,
-    reserved: *mut core::ffi::c_void,
+    pub reserved: *mut core::ffi::c_void,
 
     pub load_options_size: u32,
     pub load_options: *mut core::ffi::c_void,


### PR DESCRIPTION
Other reserved fields in the definitions in this crate are also exposed.

Fixes: #10 

Signed-off-by: Rob Bradford <robert.bradford@intel.com>