### PR TITLE
base/status: Expose value function

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -533,7 +533,7 @@ impl Status {
         Status(v)
     }
 
-    fn value(&self) -> usize {
+    pub fn value(&self) -> usize {
         self.0
     }
 


### PR DESCRIPTION
As such, we can use status.value() to get the number.

Signed-off-by: Jiewen Yao <jiewen.yao@intel.com>